### PR TITLE
QOL improvements to timeslot management

### DIFF
--- a/ratatoskr/app/templates/app/layouts/schedule_base.html
+++ b/ratatoskr/app/templates/app/layouts/schedule_base.html
@@ -39,8 +39,20 @@
                     </div>
                     Select All
                 </button>
-                <button onclick="return confirm(`Are you sure you want to delete these timeslots?`)" formaction="{% url 'schedule-delete' schedule.id %}" class="btn btn-danger" v-bind:disabled="checked == 0"><i class="far fa-trash-alt"></i> Delete</button>
-                <button onclick="return confirm(`Are you sure you want to toggle the lock on these timeslots?`)" formaction="{% url 'schedule-lock' schedule.id %}" class="btn btn-warning" v-bind:disabled="checked == 0"><i class="fas fa-lock"></i> Lock/Unlock</button>
+                <button
+                    onclick="return confirm(`Are you sure you want to delete these timeslots?`)"
+                    formaction="{% url 'schedule-delete' schedule.id %}?next={{ request.path }}"
+                    class="btn btn-danger"
+                    v-bind:disabled="checked == 0">
+                    <i class="far fa-trash-alt"></i> Delete
+                </button>
+                <button
+                    onclick="return confirm(`Are you sure you want to toggle the lock on these timeslots?`)"
+                    formaction="{% url 'schedule-lock' schedule.id %}?next={{ request.path }}"
+                    class="btn btn-warning"
+                    v-bind:disabled="checked == 0">
+                    <i class="fas fa-lock"></i> Lock/Unlock
+                </button>
             </div>
         {% endif %}
         <div class="card-body" id="timeslot-body">

--- a/ratatoskr/app/templates/app/pages/schedule_day.html
+++ b/ratatoskr/app/templates/app/pages/schedule_day.html
@@ -36,5 +36,9 @@
                 </div>
             </a>
         </div>
+    {% empty %}
+        <div class="pt-2">
+            <p class="text-center"> It seems that there are no timeslots for this day...</p>
+        </div>
     {% endfor %}
 {% endblock schedule_body %}

--- a/ratatoskr/app/views.py
+++ b/ratatoskr/app/views.py
@@ -5,6 +5,7 @@ from tokenize import group
 from django.shortcuts import redirect, render
 from django.http import HttpResponse
 from django.core.exceptions import PermissionDenied
+from django.urls import resolve
 from django.utils import dateparse, timezone
 from django.utils.timezone import make_aware
 
@@ -90,7 +91,8 @@ def schedule_delete(request, schedule_id):
     for id in timeslot_ids:
         TimeSlot.objects.filter(schedule=schedule, pk=id).delete()
 
-    return redirect("schedule", schedule_id)
+    return redirect(request.GET["next"] or "/")
+
 
 # Toggles locking of timeslots
 def schedule_lock(request, schedule_id):
@@ -117,7 +119,7 @@ def schedule_lock(request, schedule_id):
             timeslot.is_locked = not timeslot.is_locked
         TimeSlot.objects.bulk_update(timeslots, ['is_locked'])
 
-    return redirect("schedule", schedule_id)
+    return redirect(request.GET["next"] or "/")
 
 
 def create_timeslots(request, schedule_id):


### PR DESCRIPTION
A little message for if there are no timeslots for a day, and now preforming actions on timeslots should redirect you to the current page instead of the dates page.