### PR TITLE
Account for Chrome's form state restoration, add shift click selection

### DIFF
--- a/ratatoskr/app/templates/app/layouts/base.html
+++ b/ratatoskr/app/templates/app/layouts/base.html
@@ -89,7 +89,7 @@
         // nya~
         window.onload = () => {
             PetiteVue.createApp({
-                $delimiters: ["[", "]"]
+                $delimiters: ["${", "}"]
             }).mount()
             let tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
             let tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {

--- a/ratatoskr/app/templates/app/layouts/base.html
+++ b/ratatoskr/app/templates/app/layouts/base.html
@@ -87,13 +87,15 @@
 
     <script>
         // nya~
-        PetiteVue.createApp({
-            $delimiters: ["[", "]"]
-        }).mount()
-        var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
-        var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
-            return new bootstrap.Tooltip(tooltipTriggerEl)
-        })
+        window.onload = () => {
+            PetiteVue.createApp({
+                $delimiters: ["[", "]"]
+            }).mount()
+            let tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
+            let tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+                return new bootstrap.Tooltip(tooltipTriggerEl)
+            })
+        }
     </script>
 </body>
 </html>

--- a/ratatoskr/app/templates/app/layouts/schedule_listing.html
+++ b/ratatoskr/app/templates/app/layouts/schedule_listing.html
@@ -11,7 +11,6 @@
         class="m-0 p-0"
         method="POST"
         action="{% url 'schedule-edit' schedule.id %}?next={{ request.path }}">
-        ${checked}
         {% csrf_token %}
         <script>
             function onChanged(shiftClicked) {

--- a/ratatoskr/app/templates/app/layouts/schedule_listing.html
+++ b/ratatoskr/app/templates/app/layouts/schedule_listing.html
@@ -1,7 +1,15 @@
 {% extends 'app/layouts/schedule_base.html' %}
 
 {% block schedule_card %}
-    <form v-scope="{ checked: 0 }" class="m-0 p-0" method="POST" action="{% url 'schedule-edit' schedule.id %}?next={{ request.path }}">
+    <form
+        v-scope="{ 
+            checked: Array.from(document.querySelectorAll('#timeslot-body input[type=checkbox]'))
+                        .filter(x => x.checked)
+                        .length
+        }"
+        class="m-0 p-0"
+        method="POST"
+        action="{% url 'schedule-edit' schedule.id %}?next={{ request.path }}">
         {% csrf_token %}
         {% if user == schedule.owner %}
             <div class="w-100 ps-3 p-2 bg-light shadow-sm rounded" v-scope="{ checkboxes: Array.from(document.querySelectorAll('#timeslot-body input[type=checkbox]')) }">

--- a/ratatoskr/app/templates/app/layouts/schedule_listing.html
+++ b/ratatoskr/app/templates/app/layouts/schedule_listing.html
@@ -5,12 +5,31 @@
         v-scope="{ 
             checked: Array.from(document.querySelectorAll('#timeslot-body input[type=checkbox]'))
                         .filter(x => x.checked)
-                        .length
+                        .length,
+            shiftClicked: []
         }"
         class="m-0 p-0"
         method="POST"
         action="{% url 'schedule-edit' schedule.id %}?next={{ request.path }}">
+        ${checked}
         {% csrf_token %}
+        <script>
+            function onChanged(shiftClicked) {
+                if (shiftClicked.length != 2)
+                    return
+                const checkboxes = Array.from(document.querySelectorAll('#timeslot-body input[type=checkbox]'))
+                const [checkA, checkB] = shiftClicked
+                const [indexA, indexB] = [checkboxes.indexOf(checkA), checkboxes.indexOf(checkB)].sort()
+                const checks = checkboxes.slice(indexA+1, indexB)
+                if (!checks.every((x, _, a) => x.checked == a[0].checked))
+                    checks.filter(x => !x.checked).forEach(x => x.click())
+                else
+                    checks.forEach(x => x.click())
+                shiftClicked.pop()
+                shiftClicked.pop()
+            }
+        </script>
+        <div v-effect="onChanged(shiftClicked); "></div>
         {% if user == schedule.owner %}
             <div class="w-100 ps-3 p-2 bg-light shadow-sm rounded" v-scope="{ checkboxes: Array.from(document.querySelectorAll('#timeslot-body input[type=checkbox]')) }">
                 <script>

--- a/ratatoskr/app/templates/app/pages/schedule.html
+++ b/ratatoskr/app/templates/app/pages/schedule.html
@@ -23,6 +23,7 @@
                         name="timeslot_date" 
                         value="{{ date|date:"c" }}" 
                         style="width: 30px; height: 30px"
+                        @click.shift="shiftClicked.push($el)"
                         @change="checked += $el.checked ? 1 : -1" />
                     </div>
                 {% endif %}

--- a/ratatoskr/app/templates/app/pages/schedule_day.html
+++ b/ratatoskr/app/templates/app/pages/schedule_day.html
@@ -32,6 +32,7 @@
                         name="timeslot_id" 
                         value="{{ timeslot.id }}" 
                         style="width: 30px; height: 30px"
+                        @click.shift="shiftClicked.push($el)"
                         @change="checked += $el.checked ? 1 : -1" />
                     </div>
                 {% endif %}


### PR DESCRIPTION
Chrome has this feature where if you fill out a form, go to another page, then go back to the page that held that form, Chrome will restore the state of the form. This is a pretty neat feature for the user, but how the form's state is restored kind of clashed with the way we mounted PetiteVue.

The way we mounted is through an inline script tag at the bottom of the page. When this script tag is being executed, DOM rendering is effectively halted until the end of the script's execution. 

Now how is this relevant to Chrome restoring the state of the form? Chrome restores the form AFTER the DOM is rendered, which means that while PetiteVue is mounting and rendering the DOM template, it does not see the restored form. 

The fix for this behavior would be to mount PetiteVue after the document finishes rendering, which can be easily done by just passing the mounting behavior to the `window.onload` event.

Just writing all this because this is good information to know.