### PR TITLE
Easy single timeslot creation with new Bootstrap form

### DIFF
--- a/ratatoskr/app/forms.py
+++ b/ratatoskr/app/forms.py
@@ -7,7 +7,7 @@ class TimeslotGenerationForm(forms.Form):
     to_date = forms.DateField(widget=forms.DateInput(attrs={'type': 'date'}))
     from_time = forms.TimeField(widget=forms.DateInput(attrs={'type': 'time'}))
     to_time = forms.TimeField(widget=forms.DateInput(attrs={'type': 'time'}))
-    single_timeslot = forms.BooleanField(initial=False, required=False)
+    multiple_timeslots = forms.BooleanField(initial=False, required=False)
     timeslot_length = forms.IntegerField(required=False)
     timeslot_break = forms.IntegerField(required=False)
     openings = forms.IntegerField()

--- a/ratatoskr/app/forms.py
+++ b/ratatoskr/app/forms.py
@@ -7,8 +7,9 @@ class TimeslotGenerationForm(forms.Form):
     to_date = forms.DateField(widget=forms.DateInput(attrs={'type': 'date'}))
     from_time = forms.TimeField(widget=forms.DateInput(attrs={'type': 'time'}))
     to_time = forms.TimeField(widget=forms.DateInput(attrs={'type': 'time'}))
-    timeslot_length = forms.IntegerField()
-    timeslot_break = forms.IntegerField()
+    single_timeslot = forms.BooleanField(initial=False, required=False)
+    timeslot_length = forms.IntegerField(required=False)
+    timeslot_break = forms.IntegerField(required=False)
     openings = forms.IntegerField()
 
     def clean(self):

--- a/ratatoskr/app/forms.py
+++ b/ratatoskr/app/forms.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.contrib.postgres.forms import SimpleArrayField
 
+
 class TimeslotGenerationForm(forms.Form):
     from_date = forms.DateField(widget=forms.DateInput(attrs={'type': 'date'}))
     to_date = forms.DateField(widget=forms.DateInput(attrs={'type': 'date'}))
@@ -18,12 +19,14 @@ class TimeslotGenerationForm(forms.Form):
         #      raise forms.ValidationError('The start time must be earlier than the end time.')
         return cleaned_data
 
+
 class ReservationForm(forms.Form):
     name = forms.CharField(max_length=747)
     email = forms.EmailField()
     comment = forms.CharField(max_length=256)
     # TODO: Find out how to store phone numbers
-    #phone = models.PhoneNumberField()
+    # phone = models.PhoneNumberField()
+
 
 class ScheduleCreationForm(forms.Form):
     name = forms.CharField(max_length=64)

--- a/ratatoskr/app/templates/app/pages/create_timeslots.html
+++ b/ratatoskr/app/templates/app/pages/create_timeslots.html
@@ -14,7 +14,7 @@
                 <h2 class="mt-2">Create Timeslots</h2>
             </div>
             <div class="card-body">
-                <form method="POST">
+                <form method="POST" v-scope="{ multipleTimeslots: true }">
                     {% csrf_token %}
                     <div class="row g-2">
                         <div class="mb-3 col">
@@ -36,21 +36,28 @@
                             <input type="time" class="form-control" id="to_time" name="to_time">
                         </div>
                     </div>
-                    <div class="mb-3">
-                        <label for="timeslot_length" class="form-label">Timeslot Length</label>
-                        <input type="number" class="form-control" id="timeslot_length" aria-describedby="timeslotLengthHelp" name="timeslot_length">
-                        <div id="timeslotLengthHelp" class="form-text">This is the length of each timeslot in minutes, between the start time and the end time.</div>
+                    <div class="form-check form-switch mb-3">
+                      <input class="form-check-input" type="checkbox" id="multiple_timeslots" @click="multipleTimeslots = $el.checked" checked>
+                      <label class="form-check-label" for="multiple_timeslots" v-html="multipleTimeslots ? 'Single Timeslot' : 'Multiple Timeslots'"></label>
                     </div>
-                    <div class="mb-3">
-                        <label for="timeslot_break" class="form-label">Timeslot Break</label>
-                        <input type="number" class="form-control" id="timeslot_break" aria-describedby="timeslotBreakHelp" name="timeslot_break">
-                        <div id="timeslotBreakHelp" class="form-text">This is the length of time in minutes, between each of the timeslot lengths.</div>
+                    <div v-bind:style="{ display: multipleTimeslots ? 'none' : 'block' }">
+                        <div class="mb-3">
+                            <label for="timeslot_length" class="form-label">Timeslot Length</label>
+                            <input type="number" class="form-control" id="timeslot_length" aria-describedby="timeslotLengthHelp" name="timeslot_length">
+                            <div id="timeslotLengthHelp" class="form-text">This is the length of each timeslot in minutes, between the start time and the end time.</div>
+                        </div>
+                        <div class="mb-3">
+                            <label for="timeslot_break" class="form-label">Timeslot Break</label>
+                            <input type="number" class="form-control" id="timeslot_break" aria-describedby="timeslotBreakHelp" name="timeslot_break">
+                            <div id="timeslotBreakHelp" class="form-text">This is the length of time in minutes, between each of the timeslot lengths.</div>
+                        </div>
                     </div>
                     <div class="mb-3">
                         <label for="openings" class="form-label">Openings</label>
                         <input type="number" class="form-control" id="openings" aria-describedby="openingsHelp" name="openings">
                         <div id="openingsHelp" class="form-text">The number of openings for each timeslot.</div>
                     </div>
+
                     <fieldset class="text-center">
                         <button class="btn btn-primary w-50" type="submit">Create</button>
                     </fieldset>

--- a/ratatoskr/app/templates/app/pages/create_timeslots.html
+++ b/ratatoskr/app/templates/app/pages/create_timeslots.html
@@ -37,7 +37,7 @@
                         </div>
                     </div>
                     <div class="form-check form-switch mb-3">
-                      <input class="form-check-input" type="checkbox" id="multiple_timeslots" @click="multipleTimeslots = $el.checked" checked>
+                      <input class="form-check-input" type="checkbox" id="multiple_timeslots" @click="multipleTimeslots = $el.checked" name="single_timeslot" checked>
                       <label class="form-check-label" for="multiple_timeslots" v-html="multipleTimeslots ? 'Single Timeslot' : 'Multiple Timeslots'"></label>
                     </div>
                     <div v-bind:style="{ display: multipleTimeslots ? 'none' : 'block' }">

--- a/ratatoskr/app/templates/app/pages/create_timeslots.html
+++ b/ratatoskr/app/templates/app/pages/create_timeslots.html
@@ -14,7 +14,7 @@
                 <h2 class="mt-2">Create Timeslots</h2>
             </div>
             <div class="card-body">
-                <form method="POST" v-scope="{ multipleTimeslots: true }">
+                <form method="POST" v-scope="{ multipleTimeslots: false }">
                     {% csrf_token %}
                     <div class="row g-2">
                         <div class="mb-3 col">
@@ -37,10 +37,13 @@
                         </div>
                     </div>
                     <div class="form-check form-switch mb-3">
-                      <input class="form-check-input" type="checkbox" id="multiple_timeslots" @click="multipleTimeslots = $el.checked" name="single_timeslot" checked>
-                      <label class="form-check-label" for="multiple_timeslots" v-html="multipleTimeslots ? 'Single Timeslot' : 'Multiple Timeslots'"></label>
+                      <input class="form-check-input" type="checkbox" id="multiple_timeslots" @click="multipleTimeslots = $el.checked" name="multiple_timeslots">
+                        <label class="form-check-label" for="multiple_timeslots">
+                            <template v-if="multipleTimeslots">Multiple Timeslots</template>
+                            <template v-else>Single Timeslot</template>
+                        </label>
                     </div>
-                    <div v-bind:style="{ display: multipleTimeslots ? 'none' : 'block' }">
+                    <div v-show="multipleTimeslots">
                         <div class="mb-3">
                             <label for="timeslot_length" class="form-label">Timeslot Length</label>
                             <input type="number" class="form-control" id="timeslot_length" aria-describedby="timeslotLengthHelp" name="timeslot_length">

--- a/ratatoskr/app/templates/app/pages/create_timeslots.html
+++ b/ratatoskr/app/templates/app/pages/create_timeslots.html
@@ -3,16 +3,57 @@
 {% block title %}Create Timeslots{% endblock title %}
 
 {% block body %}
+    {% if errors %}
+        <div class="alert alert-danger" role="alert">
+          {{ errors }}
+        </div>
+    {% endif %}
     <div class="d-flex justify-content-center align-items-center h-75">
-        <div class="card w-50 h-50">
+        <div class="card w-75 h-50">
             <div class="card-header text-center">
                 <h2 class="mt-2">Create Timeslots</h2>
             </div>
             <div class="card-body">
                 <form method="POST">
                     {% csrf_token %}
-                    {{ form.as_p }}
-                    <input class="btn btn-primary" type="submit">
+                    <div class="row g-2">
+                        <div class="mb-3 col">
+                            <label for="from_date" class="form-label">Date From</label>
+                            <input type="date" class="form-control" id="from_date" name="from_date">
+                        </div>
+                        <div class="mb-3 col">
+                            <label for="to_date" class="form-label">Date To</label>
+                            <input type="date" class="form-control" id="to_date" name="to_date">
+                        </div>
+                    </div>
+                    <div class="row g-2">
+                        <div class="mb-3 col">
+                            <label for="from_time" class="form-label">Time From</label>
+                            <input type="time" class="form-control" id="from_time" name="from_time">
+                        </div>
+                        <div class="mb-3 col">
+                            <label for="to_time" class="form-label">Time To</label>
+                            <input type="time" class="form-control" id="to_time" name="to_time">
+                        </div>
+                    </div>
+                    <div class="mb-3">
+                        <label for="timeslot_length" class="form-label">Timeslot Length</label>
+                        <input type="number" class="form-control" id="timeslot_length" aria-describedby="timeslotLengthHelp" name="timeslot_length">
+                        <div id="timeslotLengthHelp" class="form-text">This is the length of each timeslot in minutes, between the start time and the end time.</div>
+                    </div>
+                    <div class="mb-3">
+                        <label for="timeslot_break" class="form-label">Timeslot Break</label>
+                        <input type="number" class="form-control" id="timeslot_break" aria-describedby="timeslotBreakHelp" name="timeslot_break">
+                        <div id="timeslotBreakHelp" class="form-text">This is the length of time in minutes, between each of the timeslot lengths.</div>
+                    </div>
+                    <div class="mb-3">
+                        <label for="openings" class="form-label">Openings</label>
+                        <input type="number" class="form-control" id="openings" aria-describedby="openingsHelp" name="openings">
+                        <div id="openingsHelp" class="form-text">The number of openings for each timeslot.</div>
+                    </div>
+                    <fieldset class="text-center">
+                        <button class="btn btn-primary w-50" type="submit">Create</button>
+                    </fieldset>
                 </form>
             </div>
         </div>

--- a/ratatoskr/app/templates/app/pages/schedule.html
+++ b/ratatoskr/app/templates/app/pages/schedule.html
@@ -2,7 +2,7 @@
 
 {% block schedule_head %}
     <div class="d-flex align-items-center">
-        <h3>Available Days</h3>
+        <h3 class="mb-0">Available Days</h3>
         {% if schedule.owner == user %}
             <a class="btn btn-primary ms-auto" href="{% url "create-timeslots" schedule.id %}">+ Add Timeslots</a>
         {% endif %}

--- a/ratatoskr/app/views.py
+++ b/ratatoskr/app/views.py
@@ -16,7 +16,6 @@ from django.views.decorators.http import require_http_methods
 from app.calendarutil import create_calendar_for_schedule, update_timeslot_event
 from googleapiclient.errors import HttpError
 
-
 from ratatoskr.celery import debug_task, send_mail_task
 
 from .forms import ReservationForm, ScheduleCreationForm, TimeslotGenerationForm
@@ -40,11 +39,11 @@ def create_schedule(request):
         if not form.is_valid():
             render(request, 'app/pages/create_schedule.html', {
                 "errors": form.errors
-            }) # TODO: Render form errors in template or something
+            })  # TODO: Render form errors in template or something
         lock_date = datetime.datetime.now() + datetime.timedelta(days=99999)
         if form.cleaned_data.get("should_lock_automatically"):
             lock_date = form.cleaned_data.get("auto_lock_after")
-        
+
         new_schedule = Schedule.objects.create(
             owner=request.user,
             name=form.cleaned_data["name"],
@@ -154,9 +153,7 @@ def create_timeslots(request, schedule_id):
     if request.POST:
         form = TimeslotGenerationForm(request.POST)
         if not form.is_valid():
-            return render(request, "app/pages/create_timeslots.html", {
-                "form": form
-            })
+            return render(request, "app/pages/create_timeslots.html", {"errors": form.errors})
 
         dates = pd.date_range(form.cleaned_data["from_date"], form.cleaned_data["to_date"])
         # The "-" operator only works on datetime objects and not time. Just use datetime.combine to get a datetime with the needed times to get the delta of
@@ -214,9 +211,7 @@ def create_timeslots(request, schedule_id):
 
         return redirect("schedule", schedule_id)
 
-    return render(request, "app/pages/create_timeslots.html", {
-        "form": TimeslotGenerationForm()
-    })
+    return render(request, "app/pages/create_timeslots.html", {})
 
 
 @require_http_methods(["GET", "POST"])
@@ -253,6 +248,7 @@ def reserve_confirmed(request):
     return render(request, "app/pages/reserve_confirmed.html", {
 
     })
+
 
 def test(request):
     something = build_calendar_client(request.user)

--- a/ratatoskr/app/views.py
+++ b/ratatoskr/app/views.py
@@ -164,7 +164,7 @@ def create_timeslots(request, schedule_id):
 
         base = datetime.datetime.combine(form.cleaned_data["from_date"], form.cleaned_data["from_time"])
 
-        if form.cleaned_data["single_timeslot"]:
+        if not form.cleaned_data["multiple_timeslots"]:
             TimeSlot(
                 schedule=schedule,
                 time_from=make_aware(from_time),

--- a/ratatoskr/app/views.py
+++ b/ratatoskr/app/views.py
@@ -158,56 +158,66 @@ def create_timeslots(request, schedule_id):
         dates = pd.date_range(form.cleaned_data["from_date"], form.cleaned_data["to_date"])
         # The "-" operator only works on datetime objects and not time. Just use datetime.combine to get a datetime with the needed times to get the delta of
         from_time = datetime.datetime.combine(form.cleaned_data["from_date"], form.cleaned_data["from_time"])
-        to_time = datetime.datetime.combine(form.cleaned_data["from_date"], form.cleaned_data["to_time"])
+        to_time = datetime.datetime.combine(form.cleaned_data["to_date"], form.cleaned_data["to_time"])
         time_delta = to_time - from_time
         time_delta_mins = int(time_delta.seconds / 60)
 
         base = datetime.datetime.combine(form.cleaned_data["from_date"], form.cleaned_data["from_time"])
-        length = form.cleaned_data["timeslot_length"]
-        break_length = form.cleaned_data["timeslot_break"]
-        total_buffer = length + break_length
 
-        # To the poor student who has to maintain this code in 2 years time: Good luck lmao
-        # Listen closely, as I will attempt to explain what the heck is going on in this hellspawn of a list comprehension
-        # base, as defined earlier, will represent the start of the list of timeslots. Ignore the date component, I just made it a datetime so I can do timedelta operations on it.
-        # I iterate over every date in the date range created earlier (dates)
-        # For each of these, I use range to get every offset available for each timeslot, from 0 (no offset) to time_delta_mins (max offset)
-        # total_buffer is the combined time of the length of each timeslot and the length of the breaks between the timeslots. I use this as the skip parameter for range. This should create the timeslots with the appropriate time for the meeting and the break time in between
-        # For every available offset, I make a tuple containing:
-        # The date
-        # The base plus the offset
-        # The base plus the offset and the length of the meeting
-        # Thats all I can say about this horrible thing
-        # Good luck
-        timeslot_times = [
-            [
-                (
-                    date,
-                    (base + datetime.timedelta(minutes=minute_offset)).time(),
-                    (base + datetime.timedelta(minutes=minute_offset + length)).time()
-                )
-                for minute_offset in range(0, time_delta_mins, total_buffer)
-            ]
-            for date in dates
-        ]
-
-        # The resulting list will be a 2d list, with each list being the timeslots for one day.
-        # Each list is a list of tuples with the following data:
-        # Date, time_from, time_to
-        flattened = sum(timeslot_times, [])
-
-        objects = [
+        if form.cleaned_data["single_timeslot"]:
             TimeSlot(
                 schedule=schedule,
-                time_from=make_aware(datetime.datetime.combine(date, time_from)),
-                time_to=make_aware(datetime.datetime.combine(date, time_to)),
+                time_from=make_aware(from_time),
+                time_to=make_aware(to_time),
                 reservation_limit=form.cleaned_data["openings"],
                 is_locked=False,
                 auto_lock_after=make_aware(datetime.datetime.now() + datetime.timedelta(days=500000))
-            ) for date, time_from, time_to in flattened
-        ]
+            ).save()
+        else:
+            length = form.cleaned_data["timeslot_length"]
+            break_length = form.cleaned_data["timeslot_break"]
+            total_buffer = length + break_length
 
-        TimeSlot.objects.bulk_create(objects)
+            # To the poor student who has to maintain this code in 2 years time: Good luck lmao Listen closely,
+            # as I will attempt to explain what the heck is going on in this hellspawn of a list comprehension base,
+            # as defined earlier, will represent the start of the list of timeslots. Ignore the date component,
+            # I just made it a datetime so I can do timedelta operations on it. I iterate over every date in the date
+            # range created earlier (dates) For each of these, I use range to get every offset available for each
+            # timeslot, from 0 (no offset) to time_delta_mins (max offset) total_buffer is the combined time of the
+            # length of each timeslot and the length of the breaks between the timeslots. I use this as the skip
+            # parameter for range. This should create the timeslots with the appropriate time for the meeting and the
+            # break time in between For every available offset, I make a tuple containing: The date The base plus the
+            # offset The base plus the offset and the length of the meeting Thats all I can say about this horrible
+            # thing Good luck
+            timeslot_times = [
+                [
+                    (
+                        date,
+                        (base + datetime.timedelta(minutes=minute_offset)).time(),
+                        (base + datetime.timedelta(minutes=minute_offset + length)).time()
+                    )
+                    for minute_offset in range(0, time_delta_mins, total_buffer)
+                ]
+                for date in dates
+            ]
+
+            # The resulting list will be a 2d list, with each list being the timeslots for one day.
+            # Each list is a list of tuples with the following data:
+            # Date, time_from, time_to
+            flattened = sum(timeslot_times, [])
+
+            objects = [
+                TimeSlot(
+                    schedule=schedule,
+                    time_from=make_aware(datetime.datetime.combine(date, time_from)),
+                    time_to=make_aware(datetime.datetime.combine(date, time_to)),
+                    reservation_limit=form.cleaned_data["openings"],
+                    is_locked=False,
+                    auto_lock_after=make_aware(datetime.datetime.now() + datetime.timedelta(days=500000))
+                ) for date, time_from, time_to in flattened
+            ]
+
+            TimeSlot.objects.bulk_create(objects)
 
         return redirect("schedule", schedule_id)
 


### PR DESCRIPTION
Covering issue #93 by adding new option for single timeslot creation, as well as changes in views.py to implement this.

Also improved the timeslot creation form to use Bootstrap theming.

Some file formatting fixed as well with PEP standards. Also fixed what seems to be a mistake here:

I changed `to_time = datetime.datetime.combine(form.cleaned_data["from_date"], form.cleaned_data["to_time"])`
to `to_time = datetime.datetime.combine(form.cleaned_data["to_date"], form.cleaned_data["to_time"])`