### PR TITLE
Id conflict fix

### DIFF
--- a/ratatoskr/app/calendarutil.py
+++ b/ratatoskr/app/calendarutil.py
@@ -23,9 +23,9 @@ from numpy import byte
 # comply with the base32 rule for event ids
 
 if ratatoskr.settings.DEBUG:
-    CALENDAR_ID_SUFFIX = "meetings.techhigh.us"
-else:
     CALENDAR_ID_SUFFIX = "debug.meetings.techhigh.us"
+else:
+    CALENDAR_ID_SUFFIX = "meetings.techhigh.us"
 
 CALENDAR_TIMESLOT_EVENT_ID = "%(timeslot_id)s@%(schedule_id)s#" + CALENDAR_ID_SUFFIX
 

--- a/ratatoskr/app/calendarutil.py
+++ b/ratatoskr/app/calendarutil.py
@@ -1,5 +1,6 @@
 import base64
 import datetime
+import ratatoskr.settings
 import hashlib
 from django.utils.timezone import make_aware
 from pydoc import cli
@@ -20,7 +21,12 @@ from numpy import byte
 
 # Effectively we construct a string that identifies the timeslot and pass it through SHA-1 to reduce the chance of collision and...
 # comply with the base32 rule for event ids
-CALENDAR_ID_SUFFIX = "ratatoskr.techhigh.us"
+
+if ratatoskr.settings.DEBUG:
+    CALENDAR_ID_SUFFIX = "meetings.techhigh.us"
+else:
+    CALENDAR_ID_SUFFIX = "debug.meetings.techhigh.us"
+
 CALENDAR_TIMESLOT_EVENT_ID = "%(timeslot_id)s@%(schedule_id)s#" + CALENDAR_ID_SUFFIX
 
 
@@ -106,11 +112,6 @@ def delete_calendar_for_schedule(schedule) -> None:
 # If the event does not exist, this function will create one
 def update_timeslot_event(timeslot) -> None:
     client = build_calendar_client(timeslot.schedule.owner)
-    
-    # Delete the timeslot if the timeslot has no reservations
-    if timeslot.reservation_set.count() == 0:
-        delete_timeslot_event(timeslot)
-        return
 
     calendar_id = timeslot.schedule.calendar_id
     event_id = build_timeslot_event_id(timeslot)
@@ -120,9 +121,17 @@ def update_timeslot_event(timeslot) -> None:
     # so we basically have to resort to this monkey buisness of naivifying these times then setting it back to EST to 
     # *somehow* make these times convert the correct way.
     # TODO: Abolish daylight savings time
-    east = pytz.timezone("America/New_York")
-    start = east.localize(timeslot.time_from.replace(tzinfo=None)).isoformat()
-    end = east.localize(timeslot.time_to.replace(tzinfo=None)).isoformat()
+
+    if timeslot.reservation_set.count() != 0:
+        # Normal time if timeslot has reservations
+        east = pytz.timezone("America/New_York")
+        start = east.localize(timeslot.time_from.replace(tzinfo=None)).isoformat()
+        end = east.localize(timeslot.time_to.replace(tzinfo=None)).isoformat()
+    else:
+        # Hide event if there are no reservations
+        utc = pytz.timezone("UTC")
+        start = utc.localize(datetime.datetime(1970, 1, 1)).isoformat()
+        end = utc.localize(datetime.datetime(1970, 1, 1)).isoformat()
 
     event_body = {
         "summary": f"Ratatoskr: {timeslot.schedule.name}",

--- a/ratatoskr/app/templates/app/layouts/base.html
+++ b/ratatoskr/app/templates/app/layouts/base.html
@@ -21,7 +21,7 @@
     <!-- Navbar -->
     <nav class="navbar navbar-expand-lg navbar-light bg-light shadow mb-3">
         <div class="container-fluid px-5 ">
-            <a class="navbar-brand mb-0 h1" href="{% url "index" %}">ratatoskr</a>
+            <a class="navbar-brand mb-0 h1" href="{% url "index" %}">ratatoskr <small class="text-secondary">meeting system</small></a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#myNavbar" aria-controls="myNavbar" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>


### PR DESCRIPTION
Fix for a bug with Google Calendar where deleted events could not be created again due to their id's being reserved forever. This change makes it so that when a timeslot's reservation count becomes 0, instead of deleting the event associated with it, it will instead send the event back to `1970-01-01 0:00 UTC` effectively hiding it instead of the previous behavior of deleting the event. I planned on implementing these changes with my async queuing system I am working on but I think these changes would probably be helpful now.

Also adds the subtitle that I forgot to commit into my last PR (#116). Whoops. 