### PR TITLE
Use tables for multi-timeslot demonstration, fix darkmode style for table

### DIFF
--- a/ratatoskr/app/templates/app/pages/help.html
+++ b/ratatoskr/app/templates/app/pages/help.html
@@ -134,8 +134,36 @@
                 <div class="row">
                   <div class="col">
                     Such a schedule would look like this:
-                
-                    <img src="{% static 'assets/multi-timeslot-demonstration.png' %}" width="400" height="100" class="rounded mx-auto d-block"><br>
+                    <table class="table w-100">
+                      <thead>
+                        <tr>
+                          <th scope="col">May 01</th>
+                          <th scope="col">May 02</th>
+                          <th scope="col">May 03</th>
+                          <th scope="col">May 04</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr>
+                          <td>1:00-1:25</td>
+                          <td>1:00-1:25</td>
+                          <td>1:00-1:25</td>
+                          <td>1:00-1:25</td>
+                        </tr>
+                        <tr>
+                          <td>1:30-1:55</td>
+                          <td>1:30-1:55</td>
+                          <td>1:30-1:55</td>
+                          <td>1:30-1:55</td>
+                        </tr>
+                        <tr>
+                          <td>2:00-2:25</td>
+                          <td>2:00-2:25</td>
+                          <td>2:00-2:25</td>
+                          <td>2:00-2:25</td>
+                        </tr>
+                      </tbody>
+                    </table>
 
                     What this feature does is that it generates as many 25 minute timeslots as it can between the given time. The Timeslot Break
                     field makes sure that there is 5 minutes in between each of these timeslots. <br><br>
@@ -143,7 +171,7 @@
                   </div>
                   <div class="col">
                     And the form to create this schedule would look like this:
-                    <img src="{% static 'assets/mutli-ts-form.png' %}" width="350" class="rounded mx-auto d-block"></div>
+                    <img src="{% static 'assets/mutli-ts-form.png' %}" width="500" class="rounded mx-auto d-block"></div>
                 </div>
               </p>
             </div>

--- a/ratatoskr/static/scss/app/darkmode.scss
+++ b/ratatoskr/static/scss/app/darkmode.scss
@@ -23,6 +23,10 @@ html > * {
         --accordion-button-icon-active: var(--accordion-button-icon-active-dark);
     }
 
+    .table {
+        color: $bs-dark-rgb;
+    }
+
     .accordion-button, .accordion-collapse, .accordion-item {
         background-color: #353535 !important;
     }


### PR DESCRIPTION
- readme
- Use dollar sign
- Ignore Pipfile.lock
- Add some dependencies
- Uncommit pipfile lock
- app
- Some base files stuff
- Correct readme
- Imported Bootstrap
- Configure some oauth settings
- oauth views
- Templates
- Starting on setting up Celery
- Imported celery into __init__
- Fixed typos
- Currently blocked on Google OAuth
- Added a comma because tuple
- Make template directories more standard
- Fix Django Admin (somehow)
- Update README.md
- SITE ID WAAHHH
- Try to set up petite vue
- We don't need a counter
- chmod 755 (linux qol)
- django debugging
- bodge command
- The command works
- Some more functionality
- Rename command
- Login redirect to root
- Model database
- Migrations
- Add name to reservation
- Update README.md
- WRONG LINK
- Made navbar
- Bodgey attempt at only using google auth
- comment
- Implement component
- name
- name the logout url
- login button component
- More work on the login/logout buttons
- Remove login button
- Switched navbar to a list
- Aligned navbar items to right
- Used login and logout components in navbar
- Start working on the schedule form
- margin on button
- Schedule link
- Schedule form complete
- Basic scheduling card
- Make sure user is authed
- Improve dropdown
- Standardize title tags
- Adjustments
- Removed card from base.html
- Shadow
- Collapsing checkbox
- aria (dont wanna get sued)
- commnet
- Fix tabbing, link Index for home
- Correct spelling
- text
- Display some stuff if user is staff
- Its SPAN not SPAM
- Schedule submitting is now a thing
- Remove collapsable div due to it desyncing alot
- index filter
- Schedule card now directly takes the schedule object
- Try out fontawesome
- Use stylesheet link
- Use SVG
- Fixed sizing inconsistency with profile dropdown
- Witness: One of the largetst battles with CSS ever
- Remove width (damian why)
- Display schedules on index
- Margins
- Make timezone aware
- Make schedule card link to schedule page
- Schedule page start
- Started on timeslot_card
- things
- *EXTERNAL SCREAMING*
- Day delta
- this is a debug feature
- Dictionary Expressions?
- Fight with CSS 2: Electric Boogaloo
- More featueres to the schedule page
- contanner
- text for when there are no timeslots
- Prompt the user to create timeslots if there aren't any
- generate dummy slots with different times
- desc
- Comment
- Referencing wrong user
- Use bootstrap class for nowrap
- Timeslot object in timeslot card
- what
- Implement timeslot card
- Improved timeslot card
- Add a timeslot date path
- Make the name make more sense
- Fix schedule redirect
- timeslot_date component
- Card is now link
- Basic logic for the new schedule UI
- Fixed "simple" error
- timeslot_time implemented
- Implemented timeslot_date
- Make schedule pages extend base template
- Move all converters to a seperate module
- Lets start prototyping!
- more work
- Renaming spree
- god
- hopeless bodgery
- Attempt to generate the timeslots
- Actually create the timeslots
- Link to add timeslots page
- Good luck
- Remove the +1
- stuff
- "Why not create some?" button now works
- Disable buttons based on what is checked
- Added time range to timeslot_date component
- smol thing change
- asdf
- Add client functionality for timeslot management
- Start implementing lock and delete paths
- Implemenet timeslot deletion
- Make formaction go to schedule-lock
- Rough implementation (dunno if works)
- back button
- Extended checkbox hitbox
- Multi checking logic
- Timeslot fix
- Get metadata about timeslots instead of the timeslots directly
- Time typo
- Improve the checking logic
- funky border
- this is honestly
- Checkbox does not appear if the user is not the owner
- lock toggle
- Optimize schedule locking
- Admin registry
- Move timeslot_date to template
- Fix warning spam
- Simplified timeslot_time component
- Added reserve button
- Check box component nice
- Redirection logic
- Empty condition
- Add scss
- More gitignore
- Import bootstrap scss
- Move imports
- screw
- Finish fiddling with scss file placement
- Disable links for locked timeslots
- Add locked indicators to schedules
- Schedule unlock
- Lets reduce this code duplication
- Finish schedule editing refactor
- Dont show add timeslots button on unowned schedule
- Raise PermissionDenied on users that are not an owner of the schedule
- rough implemetation
- Implement the link for the page
- bodgery
- Reservaiton logic
- Schedule layout refactor
- Use get to avoid key error
- Hapless attempt at tyring to make the list comprehension more readable
- Touches on the UI
- wiidth
- Display timeslots taken and available
- stuff
- Mount PetiteVue when the page loads instead of immediately
- Account for the fact that Chrome restores the state of forms
- shift click selecting :O
- God
- Frontend UI changes.
- UI changes and FullCalendar implementation.
- Added date range feature.
- Calendar does stuff now, yayyy
- Calendar changes
- Interface changes and calendar saving started
- Save changes for new finished
- Event changes again
- reverted
- reverted 2
- reverted 2
- Designated script block
- Schedule form model
- Don't hide date field anymore
- Form edit
- Make and implement schedule edit form
- todo: learn how the heck boolean field works
- We are going to need a custom field
- Revert "Make and implement schedule edit form"
- Revert "todo: learn how the heck boolean field works"
- god i am a mess
- cant use this
- cant use this either
- EMAIL CONSOLE BACKEND
- email task
- nothing is working
- Try to get celery to work
- Celery does not want to work. Maybe using Calendar API would  be easier
- Add calendar as a scope
- Build function now works
- Start working on calendar event insertion
- fix
- tooltip fix
- Helper functions for creating calendar element IDs
- get_calendar function
- Change access type to offline
- Modify ids to adhere to base32
- More work on calendar integeration
- Remove try/catch. We don't need it.
- Base32 encode prefix
- b32 encode the IDs
- calendar functions
- More work on the timeslots
- I hate time
- Everything should be finished
- More data refactoring...
- THESE STATS ARE ALREADY IMPLEMENTED
- People should be properly invited to the event
- times
- Handle calendar management on models
- Delete events when timeslot is deleted
- Rename method to be more clear
- Added require_http_methods and minor UI changes where absolutely neccesary (I couldn't even open schedules). Some file reformatting in PEP standards.
- Small UI tweak, url and link fixes.
- Minor UI tweak for timeslot form.
- Pull request revisions.
- Create timeslot form UI changes.
- Timeslot creation styling and single timeslot switch.
- Single timeslot creation
- Make reservation optional
- Minor changes to create_timeslots logic and view
- Starting reservation viewing page & UI changes to center things (I'm sorry but it was really bothering me)
- View reservations for each slot and email the person.
- Can now cancel reservations from each timeslot, fixed small bug with changes
- Bug in schedules page
- Schedule reservation viewing started
- schedule sorting
- Final changes for calendar reservation viewing support
- Use signals
- Rename time_slot field to timeslot for consistency
- Experimentation with converters
- Fixed merge conflict
- Add converter classes
- utilize new converters
- Raise 404 if object does not exist
- Message hello world (=
- Use _set relation instead of filtery query where possible
- Cleanup Jack's code
- Reduce code even more
- Use correct value for parent
- Format
- Changed header of toast
- Calendar delete method
- Invoke delete on calendar on schedule delete
- Dont delete an event that doesn't exist
- Account for timeslots with no reservations
- Somehow account for Daylight Savings Time government, pls abolish
- High effort comment
- Typos
- Pop up messages after the completion of certain actions
- Fixed success toast
- Fixed create schedule issue
- Rename delete signal handler
- Fix calendar events not being deleted
- First iteration of timeslot form refactor
- Another iteration...
- Final iteration
- NOT
- cenges
- Subttile
- Fix ID conflicts
- Fixed a ton of padding and margins, and some sizing to make it better for mobile screens.
- Oops forgot to fix this
- Moved templates directory (?)
- Reservation confirmation started and added some scheduling logic to prevent past dates from appearing
- Confirmation logic started.
- Fixed negative reservation counts and other calculations causing problems.
- Fixed templates as much as possible. Not easy to test without emails
- Change suffix to actually use debug
- Fail at threading the api
- Try Queue singleton
- Wow it actually works
- Actually assign it
- API Singleton now works (hopefully)
- Requested changes
- remove print
- async the damn thing
- god why are there spaces here
- 404 handler
- Make reservations use UUIDs
- 404 error page created
- red text because why not
- 400 error page
- urls for 400 page
- 403 error page great
- 500 error page great
- migration?
- Email rearangements
- removed exception from error500
- Basic footer WIP
- Github and school links in footer working
- email confirmation functionality
- Edit email templates
- More work
- Correct Links
- Backup footer
- Correct names, send email
- Separatorssssss
- Icons!!!!!
- Calendar link
- Rename
- UI tweaks for small device sizes and descriptions for schedule. Consolidated timeslot changing logic to one function.
- Fixed small issue with editing schedules by day
- Added description to schedule card and added plurality to timeslot alerts.
- New find reservation and help pages. More clearly defined how to email schedule owner. Fixed To Date issue in timeslot form.
- Fixed changes requested.
- Changed comments to textarea
- Added confirmation email resending and fixed links.
- Removed unneccesary files.
- Made URLs more consistent
- Fixed error page titles.
- Copy timeslot UI finished. Not yet functional
- Timeslots weren't being sorted by time
- Timeslots weren't being sorted by time 2
- Functionality for copying and moving timeslots...mostly
- Fully functional yayy
- Minor mobile UI changed
- Added TinyMCE support for schedule descriptions!
- Start working on rate limit optimization
- decorator
- use decorator
- typo
- Delete googleapiqueue module
- Comment
- Delete dummy even tasynchronously
- Fix escape characters being shown in textified form
- Added profile picture to make schedules more distinct
- BOLD
- Added pages: contact, help, about
- url settings
- add deps
- Production settings
- csrf
- Add -c option, more configuration
- database
- dumb stupid migrations because postgres is dumb and stupid
- dumb stupid and dumb dumb postgre databse
- deps
- Contact page  form
- Added "coming soon" to about page
- "Coming soon" for help page
- Shrunk it down to only 1 exclamation mark because it looked stupid with 3 smh
- this cant work
- ok wow
- god
- asdf
- this is honestly
- asdf
- i swear to god
- update
- lockfile
- apparently this doesnt exist
- yeet
- FIX THE BUG GOD DAMNIT
- how the hell did this bug go under the radar for the entirety of the production of the app like seriously why does django use a different url for debug and production is this like some sort of sick joke
- Screw manifest all my homies hate manifest
- remove debug
- timezone bodge
- SSL
- warn
- Word of warning
- htsts varble
- Changed so that clicking on "Contact Us!" in footer brings you to contact page
- Finishing touches on contact page
- Clicking on "github issues" opens new tab instead of redirecting
- Opens new tab when clicking on github page button in footer
- Running away from the bad line break
- Header for stuff like that ig
- Schedule deletion added. Schedule creation form disabled while waiting now. Meeting time is in reservation confirmation email now.
- Send email when confirmed or cancelled reservations. Next, send email to person with reservation when cancelled.
- Did that too
- Started schedule subscribing.
- Improvements to subscribing feature.
- Remembering to fix testing case...
- Forgot to undo this.
- More subscribing stuff
- Subscription changes to simplify it all.
- Added schedule visibility and improved some small bugs and UI tweaks
- Turns out this was resolved
- Subscription changes again.
- Fixed ACL rules for Calendar objects.
- New help page templates
- Started a dark mode thing :)
- add threadpool decorator
- Improve readability
- Add description to public schedules
- remove the F
- Switched the about page with the index and shlunked the old index
- Updated the buttons on navbar
- multithreading
- Send different emails for subscribers
- release the limit!!!
- THIS WORD IS hARD TO SPELL OK?
- 2 many bar
- Only allow those in domain to login
- Alternative values for students
- cleanup
- messages stuff
- use @login_required where possible
- Trying something new for home page
- the most wildest reverse engineering chase
- the spanish inqisition!? in my source code!?
- asdf
- sdfsdf
- Actions improvements
- License href
- Create LICENSE
- No more nav shadow
- license
- Updated contact page
- comment
- Gridding!
- COORDINATES
- make clearer
- move scripts to script block
- Basic hero
- dont  use format string
- cloak style
- We actually like shadow nvm
- Added the hero underneath the main title
- Start refactoring schedule editing
- are you sure
- More progress on the new schedule edit
- Remove schedule edit
- Formatting
- god
- asdf
- Round button for arrow button on home page
- Added alternating heroes
- LOREM IPSUM
- Message form
- Redirect to schedule owners page
- Contact form actually works now
- Feed
- stiff
- share link
- update?
- make clearer
- ugh
- Visibility on schedule page
- Replace links with buttons beacuse usability issue
- fix copy button
- Improve accessability
- Fix button changing size on mobile
- Main hero improvements
- Use api_pool here
- apply acl asynchronously
- Remove comment
- Remove the test view
- Dripdown Form
- Form Inlinification
- More Improvements
- Center the form
- Mobile navbar improvements
- Size
- Use a bootstrpa check
- Dont show on mobile
- Add are you sure to save changes
- help page styles
- yaet
- More navbar improvements
- Dropdown tweening animations
- fornt page
- Put entire body in a v-scope to prevent random breakage idk why this happens, we made no changes
- ITS HIDDEN
- Dark mode, oooohhh
- Bizarre UI fixes
- Made styles more consistent
- More UI changes
- User testing
- Historical tracking with the new dashboard
- Dashboard improvements and history implementation
- Finished dashboard, yayy
- Dashboard added to base.html
- Added get started info to home page.
- Added content to help page
- Update help.html
- django-simple-history dependency
- I made reservations more countable in schedulers point of view.
- Added content to help page
- Update help.html
- Return future from decorator and use callback to check value of result for exception
- set dark mode on page load to prevent user from being flashbanged
- correct spelling
- dark mode tweaks
- button text color white
- apply dark to form-select
- fix modifiers
- Dark theme select icon
- use bootstrpa checkbox
- fix span text not being black
- button color adjustment
- improve hover colors of outline buttons in darkmode
- Fix rgb
- we use fixed tops now
- use entire height
- Center the buttons on all screen sizes
- make buttons consistent with light theme
- Accordion indicators are themed now
- Actually theme the accordion icons
- dont use button
- unlimit days
- Fix notif layering
- Change "From, to" to "Start End"
- Dark themed editor
- commnet
- make tox select lable white
- Start contenting the about page
- more pogress
- dates
- mobileism
- item label background fix
- bene is an integration tester
- color statusbar
- tarnish this mans name
- Help timeslots
- multi timeslot explaination
- centered
- robots.txt
- Schedule subscriptions page
- empty condition
- wording
- Dont use text white here
- No schedule text
- Use a table instead of a low res image
- fix tables in dark mode
